### PR TITLE
Fix failing mixin under new mappings

### DIFF
--- a/src/main/java/net/glasslauncher/mods/gcapi3/mixin/server/JoinMixin.java
+++ b/src/main/java/net/glasslauncher/mods/gcapi3/mixin/server/JoinMixin.java
@@ -22,7 +22,7 @@ public class JoinMixin {
             method = "accept",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/entity/player/ServerPlayerEntity;method_317()V",
+                    target = "Lnet/minecraft/entity/player/ServerPlayerEntity;initScreenHandler()V",
                     shift = At.Shift.AFTER
             ),
             locals = LocalCapture.CAPTURE_FAILHARD


### PR DESCRIPTION
For some reason remap mappings didn't work on this one case, but everything else seems to have worked. This is the last unnamed method in the codebase so that's cool, but yeah connecting to a server crashes the server without this fix.